### PR TITLE
add pyo3 dockerfile and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 # Python
 
 Contains Python 3.6, 3.7 and 3.8 dockerfiles built on top of Ubuntu 20.04.
+
+Also contains a specialised dockerfile extending Python 3.8 with a stable toolchain for building & publishing [PyO3](https://github.com/PyO3/pyo3) projects with [maturin](https://github.com/PyO3/maturin) and [twine](https://github.com/pypa/twine).

--- a/python/3.8-pyo3/Dockerfile
+++ b/python/3.8-pyo3/Dockerfile
@@ -1,0 +1,19 @@
+FROM binkhq/python:3.8
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    DEBIAN_FRONTEND="noninteractive"
+
+ARG RUST_VERSION=1.44.1
+
+RUN apt-get update && \
+    apt-get -y install wget && \
+    wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" && \
+    chmod +x rustup-init && \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION && \
+    rm rustup-init && \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
+    pip install --no-cache-dir maturin twine && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
exposes `cargo`, `rustc`, `maturin`, and `twine` for building & publishing rust/pyo3 packages