### PR TITLE
add cffi to pip install in pyo3 image

### DIFF
--- a/python/3.8-pyo3/Dockerfile
+++ b/python/3.8-pyo3/Dockerfile
@@ -14,6 +14,6 @@ RUN apt-get update && \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION && \
     rm rustup-init && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
-    pip install --no-cache-dir maturin twine && \
+    pip install --no-cache-dir maturin twine cffi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
depending on the type of pyo3 build you're doing you might need cffi to be available. this change sorts that out.